### PR TITLE
Correctly handle fPassThrough for TransparentProxies

### DIFF
--- a/Indy.SChannel/lib/Execute.IdSSLSChannel.pas
+++ b/Indy.SChannel/lib/Execute.IdSSLSChannel.pas
@@ -96,10 +96,22 @@ begin
 end;
 
 procedure TIdSSLIOHandlerSocketSChannel.ConnectClient;
+var
+  LPassThrough: Boolean;
 begin
 {$IFDEF LOG_EVENTS}System.WriteLn('TIdSSLIOHandlerSocketSChannel.ConnectClient');{$ENDIF}
-//  CloseSSL;
-  inherited;
+  // RLebeau 1/11/07: In case a proxy is being used, pass through
+  // any data from the base class unencrypted when setting up that
+  // connection.  We should do this anyway since SSL hasn't been
+  // initialized yet!
+  LPassThrough := fPassThrough;
+  fPassThrough := True;
+  try
+    inherited ConnectClient;
+  finally
+    fPassThrough := LPassThrough;
+  end;
+//  DoBeforeConnect(Self);
   StartSSL;
 end;
 


### PR DESCRIPTION
This adds support for transparent proxies ( SOCKS proxies ) when TIdSSLIOHandlerSocketSChannel is used.
I tested https without proxies, http over SOCKS 5, https over SOCKS5, https over HTTPs proxy and also http over HTTPs proxy with `TIdHTTPOption.hoNonSSLProxyUseConnectVerb = True`, everything works good. 👌
Fixes #4