### PR TITLE
Removed unused local variables

### DIFF
--- a/Indy.SChannel/lib/Execute.WinSSPI.pas
+++ b/Indy.SChannel/lib/Execute.WinSSPI.pas
@@ -1343,12 +1343,9 @@ function SerialNumber(const Number: CRYPT_INTEGER_BLOB): string;
 // 0006 ->  0,  6 -> 5
 // 0000 ->      0 -> 6
 var
-  Source: Integer;
   Index : Integer;
   Value : Integer;
   Digits: Integer;
-  Store : Integer;
-  Add   : Integer;
   Bytes : TArray<Byte>;
 begin
   Digits := Number.cbData;


### PR DESCRIPTION
These local variables aren't used anywhere and produce hints.